### PR TITLE
feat: support naming record

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -16,6 +16,7 @@ type Reflector struct {
 	EmitAllFields        bool // don't skip struct fields which have no struct tags
 	SkipTagFieldNames    bool // don't use json/bson tag names, even if theyre present
 	Mapper               func(reflect.Type) any
+	NameMapping          map[string]string // 改用 map
 	Namespace            string
 	recordTypeCache      map[string]reflect.Type
 }
@@ -82,6 +83,12 @@ func (r *Reflector) handleRecord(t reflect.Type) *AvroSchema {
 	name := t.Name()
 	tokens := strings.Split(name, ".")
 	name = tokens[len(tokens)-1]
+
+	if r.NameMapping != nil {
+		if mappedName, ok := r.NameMapping[name]; ok {
+			name = mappedName
+		}
+	}
 
 	if _, ok := r.recordTypeCache[t.Name()]; ok {
 		return &AvroSchema{Name: name, Type: t.Name()}

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -661,3 +661,30 @@ func TestNamespace(t *testing.T) {
 	assert.Nil(t, err)
 	assert.JSONEq(t, expected, result)
 }
+
+func TestNameMapping(t *testing.T) {
+	type MyStruct struct {
+		Field string `json:"field"`
+	}
+
+	expected := `{
+		"name": "CustomName",
+		"type": "record",
+		"namespace": "com.example",
+		"fields": [
+			{"name": "field", "type": "string"}
+		]
+	}`
+
+	e := MyStruct{}
+	r := &Reflector{
+		Namespace: "com.example",
+		NameMapping: map[string]string{
+			"MyStruct": "CustomName",
+		},
+	}
+	result, err := r.Reflect(e)
+
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, result)
+}


### PR DESCRIPTION
When we want to override record's name, we can use `NameMapping`.